### PR TITLE
Reduce Krantzberg syndrome in magic getopt

### DIFF
--- a/tests/getopt/Makefile
+++ b/tests/getopt/Makefile
@@ -4,7 +4,7 @@ all:	test_getopt
 
 test:	all
 	@echo -n "Testing command-line options parsing... "
-	@/bin/sh -e test_getopt.sh 2>test_getopt.log
+	@/bin/sh -e test_getopt.sh 2>test_getopt.log || true
 	@if cmp -s test_getopt.log test_getopt.good; then	\
 		echo "PASSED!";					\
 	else							\
@@ -12,13 +12,13 @@ test:	all
 	fi
 
 test_getopt:	main.o getopt.o
-	${CC} -o test_getopt main.o getopt.o
+	${CC} -g -o test_getopt main.o getopt.o
 
 main.o:	main.c
-	${CC} -D_POSIX_C_SOURCE=200809L -I ../../util -c main.c -o main.o
+	${CC} -D_POSIX_C_SOURCE=200809L -I ../../util -g -c main.c -o main.o
 
 getopt.o:	../../util/getopt.c
-	${CC} -D_POSIX_C_SOURCE=200809L -I ../../util -c ../../util/getopt.c -o getopt.o
+	${CC} -D_POSIX_C_SOURCE=200809L -I ../../util -g -c ../../util/getopt.c -o getopt.o
 
 clean:
 	rm -f test_getopt

--- a/tests/getopt/main.c
+++ b/tests/getopt/main.c
@@ -73,4 +73,6 @@ main(int argc, char * argv[])
 	}
 	argc -= optind;
 	argv += optind;
+
+	return 0;
 }

--- a/tests/getopt/main.c
+++ b/tests/getopt/main.c
@@ -21,7 +21,6 @@ main(int argc, char * argv[])
 
 	/* Process arguments. */
 	while ((ch = GETOPT(argc, argv)) != NULL) {
-		if (getopt_init != getopt_init_scan)
 		fprintf(stderr, "Option being processed: %s\n", ch);
 		GETOPT_SWITCH(ch) {
 		GETOPT_OPT("-b"):
@@ -56,7 +55,6 @@ main(int argc, char * argv[])
 
 	/* Process the arguments again, with GETOPT_MISSING_ARG this time. */
 	while ((ch = GETOPT(argc, argv)) != NULL) {
-		if (getopt_init != getopt_init_scan)
 		fprintf(stderr, "Option being processed: %s\n", ch);
 		GETOPT_SWITCH(ch) {
 		GETOPT_OPT("-b"):

--- a/tests/getopt/main.c
+++ b/tests/getopt/main.c
@@ -21,6 +21,7 @@ main(int argc, char * argv[])
 
 	/* Process arguments. */
 	while ((ch = GETOPT(argc, argv)) != NULL) {
+		if (getopt_init != getopt_init_scan)
 		fprintf(stderr, "Option being processed: %s\n", ch);
 		GETOPT_SWITCH(ch) {
 		GETOPT_OPT("-b"):
@@ -55,6 +56,7 @@ main(int argc, char * argv[])
 
 	/* Process the arguments again, with GETOPT_MISSING_ARG this time. */
 	while ((ch = GETOPT(argc, argv)) != NULL) {
+		if (getopt_init != getopt_init_scan)
 		fprintf(stderr, "Option being processed: %s\n", ch);
 		GETOPT_SWITCH(ch) {
 		GETOPT_OPT("-b"):

--- a/tests/getopt/test_getopt.good
+++ b/tests/getopt/test_getopt.good
@@ -1,51 +1,215 @@
 Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
 bflag = 0
 Remaining arguments:
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
 Option being processed: (dummy)
 Option being processed: (dummy)
 Option being processed: -b
 bflag = 1
 Remaining arguments:
 Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
 Option being processed: -b
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
 Option being processed: (dummy)
 Option being processed: --bar
 bflag = 1
 Remaining arguments:
 Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
 Option being processed: --bar
 Option being processed: (dummy)
-Option being processed: -f
-foo: bar
-bflag = 0
-Remaining arguments:
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
 Option being processed: (dummy)
 Option being processed: -f
 foo: bar
+bflag = 0
+Remaining arguments:
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: -f
+foo: bar
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
 Option being processed: (dummy)
 Option being processed: --foo
 foo: bar
 bflag = 0
 Remaining arguments:
 Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
 Option being processed: --foo
 foo: bar
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
 Option being processed: (dummy)
 Option being processed: --foo
 foo: bar
 bflag = 0
 Remaining arguments:
 Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
 Option being processed: --foo
 foo: bar
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
 Option being processed: (dummy)
 Option being processed: -b
 Option being processed: -b
 bflag = 2
 Remaining arguments:
 Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
 Option being processed: -b
 Option being processed: -b
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
 Option being processed: (dummy)
 Option being processed: -b
 Option being processed: -b
@@ -54,10 +218,32 @@ foo: bar
 bflag = 2
 Remaining arguments:
 Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
 Option being processed: -b
 Option being processed: -b
 Option being processed: -f
 foo: bar
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
 Option being processed: (dummy)
 Option being processed: -b
 Option being processed: -b
@@ -66,13 +252,57 @@ foo: bar
 bflag = 2
 Remaining arguments:
 Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
 Option being processed: -b
 Option being processed: -b
 Option being processed: -f
 foo: bar
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
 Option being processed: (dummy)
 bflag = 0
 Remaining arguments: foo bar baz
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
 Option being processed: (dummy)
 Option being processed: (dummy)
 Option being processed: -b
@@ -81,15 +311,59 @@ foo: bar
 bflag = 1
 Remaining arguments: baz
 Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
 Option being processed: -b
 Option being processed: --foo
 foo: bar
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
 Option being processed: (dummy)
 Option being processed: -b
 bflag = 1
 Remaining arguments: --foo bar baz
 Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
 Option being processed: -b
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
 Option being processed: (dummy)
 test_getopt: unknown option: -a
 Option being processed: -a
@@ -97,8 +371,30 @@ usage: blah blah blah
 bflag = 0
 Remaining arguments:
 Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
 Option being processed: -a
 usage: test_getopt [-b] [-f bar] [--foo bar] ...
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
 Option being processed: (dummy)
 test_getopt: option requires an argument: -f
 Option being processed: -f
@@ -106,9 +402,31 @@ usage: blah blah blah
 bflag = 0
 Remaining arguments:
 Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
 Option being processed: -f
 missing argument
 usage: test_getopt [-b] [-f bar] [--foo bar] ...
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
 Option being processed: (dummy)
 test_getopt: option requires an argument: --foo
 Option being processed: --foo
@@ -116,15 +434,49 @@ usage: blah blah blah
 bflag = 0
 Remaining arguments:
 Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
 Option being processed: --foo
 missing argument
 usage: test_getopt [-b] [-f bar] [--foo bar] ...
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
 Option being processed: (dummy)
 test_getopt: option doesn't take an argument: --bar
 Option being processed: --bar
 usage: blah blah blah
 bflag = 0
 Remaining arguments:
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
+Option being processed: (dummy)
 Option being processed: (dummy)
 Option being processed: --bar
 usage: test_getopt [-b] [-f bar] [--foo bar] ...

--- a/util/getopt.c
+++ b/util/getopt.c
@@ -150,7 +150,7 @@ getopt(int argc, char * const argv[])
 		reset(argc, argv);
 
 	/* If not initialized, return dummy option. */
-	if (!getopt_initialized)
+	if (getopt_init < getopt_init_done)
 		return (GETOPT_DUMMY);
 
 	/* If we've run out of arguments, we're done. */
@@ -266,7 +266,7 @@ getopt_lookup(const char * os)
 		DIE("Can't reset in the middle of getopt loop");
 
 	/* We should only be called after initialization is complete. */
-	assert(getopt_initialized);
+	assert(getopt_init == getopt_init_done);
 
 	/* GETOPT_DUMMY should never get passed back to us. */
 	assert(os != GETOPT_DUMMY);

--- a/util/getopt.c
+++ b/util/getopt.c
@@ -19,7 +19,7 @@ int optreset = 1;
  * Quasi-internal global variables -- these are used via GETOPT macros.
  */
 const char * getopt_dummy = "(dummy)";
-int getopt_initialized = 0;
+enum getopt_init_state getopt_init = getopt_init_start;
 
 /*
  * Internal variables.
@@ -105,7 +105,7 @@ reset(int argc, char * const argv[])
 	opt_found = (size_t)(-1);
 
 	/* We're not initialized yet. */
-	getopt_initialized = 0;
+	getopt_init = getopt_init_start;
 
 	/* Finished resetting state. */
 	optreset = 0;
@@ -291,7 +291,7 @@ getopt_register_opt(const char * os, size_t ln, int hasarg)
 		DIE("Can't reset in the middle of getopt loop");
 
 	/* We should only be called during initialization. */
-	assert(!getopt_initialized);
+	assert(getopt_init == getopt_init_scan);
 
 	/* We should have space allocated for registering options. */
 	assert(opts != NULL);
@@ -324,7 +324,7 @@ getopt_register_missing(size_t ln)
 		DIE("Can't reset in the middle of getopt loop");
 
 	/* We should only be called during initialization. */
-	assert(!getopt_initialized);
+	assert(getopt_init == getopt_init_scan);
 
 	/* Record missing-argument value. */
 	opt_missing = ln;
@@ -340,7 +340,7 @@ getopt_setrange(size_t ln)
 		DIE("Can't reset in the middle of getopt loop");
 
 	/* We should only be called during initialization. */
-	assert(!getopt_initialized);
+	assert(getopt_init == getopt_init_range);
 
 	/* Allocate space for options. */
 	opts = malloc(ln * sizeof(struct opt));


### PR DESCRIPTION
As we know from Charlie Sross's Laundry Files novels, excessive use of magic can cause your brain to be eaten from the inside by terrible entities from another dimension.

This patch series removes `longjmp()` and `goto` from magic getopt, replacing them with `continue` and `if()`. This eliminates a lot of `sigprocmask()` calls, and makes volatile variables unnecessary thereby avoiding a large class of eldritch compiler bugs.