### PR TITLE
"echo -n" is not portable; use printf

### DIFF
--- a/tests/getopt/Makefile
+++ b/tests/getopt/Makefile
@@ -3,7 +3,7 @@
 all:	test_getopt
 
 test:	all
-	@echo -n "Testing command-line options parsing... "
+	@printf "Testing command-line options parsing... "
 	@/bin/sh -e test_getopt.sh 2>test_getopt.log || true
 	@if cmp -s test_getopt.log test_getopt.good; then	\
 		echo "PASSED!";					\

--- a/tests/heap/Makefile
+++ b/tests/heap/Makefile
@@ -3,7 +3,7 @@
 all:	test_heap
 
 test:	test_heap
-	@echo -n "Heapsorting main.c..."
+	@printf "Heapsorting main.c..."
 	@./test_heap < main.c > main.c.sorted
 	@if LC_ALL=C sort < main.c | cmp - main.c.sorted; then	\
 		echo " PASSED!";			\


### PR DESCRIPTION
    It is not possible to use echo portably across all POSIX systems unless
    both -n (as the first argument) and escape sequences are omitted.

http://pubs.opengroup.org/onlinepubs/9699919799/utilities/echo.html