### PR TITLE
Use poll(2) instead of select(2) in events/events_network.c

### DIFF
--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -3,6 +3,7 @@ under the following terms:
 
 Copyright 2005-2014 Colin Percival.  All rights reserved.
 Copyright 2014 Sean Kelly.  All rights reserved.
+Copyright 2016 Tim Duesterhus.  All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions


### PR DESCRIPTION
Closes Tarsnap/libcperciva#6
---

I've done some basic checks using spiped and valgrind. spiped transfers data and valgrind does not report any memory errors when running spiped with the `-1` option. I'm sure I still did something horribly wrong, as I never really worked with event based C networking before. I'm sure you'll examine the patch closely, as always :wink: 
