### PR TITLE
network & sock: remove <sys/types.h>

### DIFF
--- a/network/network_accept.c
+++ b/network/network_accept.c
@@ -1,4 +1,3 @@
-#include <sys/types.h>
 #include <sys/socket.h>
 
 #include <errno.h>

--- a/network/network_connect.c
+++ b/network/network_connect.c
@@ -1,4 +1,3 @@
-#include <sys/types.h>
 #include <sys/select.h>
 #include <sys/socket.h>
 

--- a/util/sock.c
+++ b/util/sock.c
@@ -1,4 +1,3 @@
-#include <sys/types.h>
 #include <sys/socket.h>
 #include <sys/un.h>
 


### PR DESCRIPTION
The <sys/types.h> header has historically been required on some systems when
<sys/socket.h> is used, but the POSIX standard states that it is not
necessary. In keeping with our policy of strict compliance, we omit these
inclusions; but it may be necessary to add them back on some buggy platforms.