### PR TITLE
crypto_aes_aesni.c: remove <string.h>

### DIFF
--- a/crypto/crypto_aes_aesni.c
+++ b/crypto/crypto_aes_aesni.c
@@ -3,7 +3,6 @@
 
 #include <stdint.h>
 #include <stdlib.h>
-#include <string.h>
 #include <wmmintrin.h>
 
 #include "insecure_memzero.h"


### PR DESCRIPTION
This was added in 999428bf145673b56d674a849e2a664bc479edc8, which used memset() in the really "insecure zero" method.  It switched to insecure_memzero() in 194cc1c7ecffe865e947087c061dd7a4caaa86f7, and I think `<string.h>` should have been removed then.