### PR TITLE
cpusupport.sh: Add workaround for bash env mangling

### DIFF
--- a/cpusupport/Build/cpusupport.sh
+++ b/cpusupport/Build/cpusupport.sh
@@ -1,5 +1,9 @@
-# Should be sourced by `command -p sh path/to/cpusupport.sh` from
+# Should be sourced by `command -p sh path/to/cpusupport.sh "$PATH"` from
 # within a Makefile.
+if ! [ ${PATH} = "$1" ]; then
+	echo "WARNING: POSIX violation: $SHELL's command -p resets \$PATH" 1>&2
+	PATH=$1
+fi
 # Standard output should be written to cpusupport-config.h, which is both a
 # C header file defining CPUSUPPORT_ARCH_FEATURE macros and sourceable sh
 # code which sets CFLAGS_ARCH_FEATURE environment variables.


### PR DESCRIPTION
For details, see
https://github.com/Tarsnap/libcperciva/commit/e86fc8afdd11c643716b9f44c6abcdc72fb21384