### PR TITLE
Rename initstate to initial_state

### DIFF
--- a/alg/sha256.c
+++ b/alg/sha256.c
@@ -187,7 +187,7 @@ SHA256_Pad(SHA256_CTX * ctx, uint32_t tmp32[static restrict 72])
 }
 
 /* Magic initialization constants. */
-static const uint32_t initstate[8] = {
+static const uint32_t initial_state[8] = {
 	0x6A09E667, 0xBB67AE85, 0x3C6EF372, 0xA54FF53A,
 	0x510E527F, 0x9B05688C, 0x1F83D9AB, 0x5BE0CD19
 };
@@ -204,7 +204,7 @@ SHA256_Init(SHA256_CTX * ctx)
 	ctx->count = 0;
 
 	/* Initialize state. */
-	memcpy(ctx->state, initstate, sizeof(initstate));
+	memcpy(ctx->state, initial_state, sizeof(initial_state));
 }
 
 /**


### PR DESCRIPTION
There is a stdlib function named 'initstate'.  The namespace collision
shouldn't matter since symbols from <stdlib.h> shouldn't be visible
when compiling a file which doesn't include that header, and our local
static variable should have linkage priority over an external symbol
with the same name, but avoid it anyway just to be safe.