### PR TITLE
libcperciva: put CPU macros inside relevant #ifdef

### DIFF
--- a/cpusupport/cpusupport_x86_aesni.c
+++ b/cpusupport/cpusupport_x86_aesni.c
@@ -2,9 +2,9 @@
 
 #ifdef CPUSUPPORT_X86_CPUID
 #include <cpuid.h>
-#endif
 
 #define CPUID_AESNI_BIT (1 << 25)
+#endif
 
 CPUSUPPORT_FEATURE_DECL(x86, aesni)
 {

--- a/cpusupport/cpusupport_x86_sse2.c
+++ b/cpusupport/cpusupport_x86_sse2.c
@@ -2,9 +2,9 @@
 
 #ifdef CPUSUPPORT_X86_CPUID
 #include <cpuid.h>
-#endif
 
 #define CPUID_SSE2_BIT (1 << 26)
+#endif
 
 CPUSUPPORT_FEATURE_DECL(x86, sse2)
 {


### PR DESCRIPTION
These macros are only used in code that is hidden by the same #ifdef.
