### PR TITLE
Switch events_network from select to poll

### DIFF
--- a/events/events_network.c
+++ b/events/events_network.c
@@ -1,37 +1,77 @@
 #include <sys/select.h>
 
+#include <assert.h>
 #include <errno.h>
+#include <limits.h>
+#include <poll.h>
+#include <stdint.h>
 #include <stdlib.h>
+#include <string.h>
 
+#include "ctassert.h"
 #include "elasticarray.h"
 #include "warnp.h"
 
 #include "events.h"
 #include "events_internal.h"
 
+/*
+ * Sanity checks on the nfds_t type: POSIX simply says "an unsigned integer
+ * type used for the number of file descriptors", but it doesn't make sense
+ * for it to be larger than size_t unless there's an undocumented limit on
+ * the number of descriptors which can be polled (since poll takes an array,
+ * the size of which must fit into a size_t); and nfds_t should be able to
+ * the value INT_MAX + 1 (in case every possible file descriptor is in use
+ * and being polled for).
+ */
+CTASSERT((nfds_t)(-1) <= (size_t)(-1));
+CTASSERT((nfds_t)((size_t)(INT_MAX) + 1) == (size_t)(INT_MAX) + 1);
+
 /* Structure for holding readability and writability events for a socket. */
 struct socketrec {
 	struct eventrec * reader;
 	struct eventrec * writer;
+	size_t pollpos;
 };
 
 /* List of sockets. */
 ELASTICARRAY_DECL(SOCKETLIST, socketlist, struct socketrec);
 static SOCKETLIST S = NULL;
 
-/* File descriptor sets containing unevented ready sockets. */
-static fd_set readfds;
-static fd_set writefds;
+/* Poll structures. */
+struct pollfd * fds;
+
+/* Number of poll structures allocated in array. */
+size_t fds_alloc;
+
+/* Number of poll structures initialized. */
+size_t nfds;
 
 /* Position to which events_network_get has scanned in *fds. */
 static size_t fdscanpos;
 
-/* Number of registered events. */
-static size_t nev;
+/**
+ * Invariants:
+ * 1. Initialized entries in S and fds point to each other:
+ *     S[i].pollpos < nfds ==> fds[S[i].pollpos].fd == i
+ *     j < nfds ==> S[fds[j].fd].pollpos == j
+ * 2. Descriptors with events registered are in the right place:
+ *     S[i].reader != NULL ==> S[i].pollpos < nfds
+ *     S[i].writer != NULL ==> S[i].pollpos < nfds
+ * 3. Descriptors without events registered aren't in the way:
+ *     (S[i].reader == NULL && S[i].writer != NULL) ==> S[i].pollpos == -1
+ * 4. Descriptors with events registered have the right masks:
+ *     S[i].reader != NULL <==> (fds[S[i].pollpos].events & POLLIN) != 0
+ *     S[i].writer != NULL <==> (fds[S[i].pollpos].events & POLLOUT) != 0
+ * 5. We don't have events ready which we don't want:
+ *     (fds[j].revents & (POLLIN | POLLOUT) & (~fds[j].events])) == 0
+ * 6. Returned events are in position to be scanned later:
+ *     fds[j].revents != 0 ==> f < fdscanpos.
+ */
 
-/* Initialize the socket list if we haven't already done so. */
+/* Initialize data structures if we haven't already done so. */
 static int
-initsocketlist(void)
+init(void)
 {
 
 	/* If we're already initialized, do nothing. */
@@ -42,11 +82,9 @@ initsocketlist(void)
 	if ((S = socketlist_init(0)) == NULL)
 		goto err0;
 
-	/* There are no events registered. */
-	nev = 0;
-
-	/* There are no unevented ready sockets. */
-	fdscanpos = FD_SETSIZE;
+	/* We have no poll structures allocated or initialzed. */
+	fds = NULL;
+	fds_alloc = nfds = fdscanpos = 0;
 
 done:
 	/* Success! */
@@ -74,6 +112,7 @@ growsocketlist(size_t nrec)
 	for (; i < nrec; i++) {
 		socketlist_get(S, i)->reader = NULL;
 		socketlist_get(S, i)->writer = NULL;
+		socketlist_get(S, i)->pollpos = (size_t)(-1);
 	}
 
 	/* Success! */
@@ -82,6 +121,78 @@ growsocketlist(size_t nrec)
 err0:
 	/* Failure! */
 	return (-1);
+}
+
+/* Add a new descriptor to the pollfd array. */
+static int
+growpollfd(size_t fd)
+{
+	size_t new_fds_alloc;
+	struct pollfd * new_fds;
+
+	/* We should not be called if the descriptor is already listed. */
+	assert(socketlist_get(S, fd)->pollpos == (size_t)(-1));
+
+	/* Expand the pollfd allocation if needed. */
+	if (fds_alloc == nfds) {
+		new_fds_alloc = fds_alloc == 0 ? 16 : fds_alloc * 2;
+		if (new_fds_alloc > SIZE_MAX / sizeof(struct pollfd)) {
+			errno = ENOMEM;
+			goto err0;
+		}
+		if ((new_fds = realloc(fds,
+		    new_fds_alloc * sizeof(struct pollfd))) == NULL)
+			goto err0;
+		fds = new_fds;
+		fds_alloc = new_fds_alloc;
+	}
+
+	/* Sanity-check. */
+	assert(nfds < fds_alloc);
+
+	/* Initialize pollfd structure. */
+	fds[nfds].fd = fd;
+	fds[nfds].events = 0;
+	fds[nfds].revents = 0;
+
+	/* Point at pollfd structure. */
+	socketlist_get(S, fd)->pollpos = nfds;
+
+	/* We now have one more pollfd structure. */
+	nfds++;
+
+	/* Success! */
+	return (0);
+
+err0:
+	/* Failure! */
+	return (-1);
+}
+
+/* Clear a bit from a pollfd and maintain invariants. */
+static void
+clearbit(size_t pollpos, short bit)
+{
+
+	/* Clear the bit. */
+	fds[pollpos].events &= ~bit;
+	fds[pollpos].revents &= ~bit;
+
+	/* Is this pollfd in the way? */
+	if (fds[pollpos].events == 0) {
+		/* Clear the descriptor's pollpos pointer. */
+		socketlist_get(S, fds[pollpos].fd)->pollpos = (size_t)(-1);
+
+		/* If this wasn't the last pollfd, move another one up. */
+		if (pollpos != nfds - 1) {
+			memcpy(&fds[pollpos], &fds[nfds-1],
+			    sizeof(struct pollfd));
+			socketlist_get(S, fds[pollpos].fd)->pollpos = pollpos;
+		}
+
+		/* Shrink the pollfd array. */
+		nfds--;
+	}
 }
 
 /**
@@ -98,11 +209,11 @@ events_network_register(int (*func)(void *), void * cookie, int s, int op)
 	struct eventrec ** r;
 
 	/* Initialize if necessary. */
-	if (initsocketlist())
+	if (init())
 		goto err0;
 
 	/* Sanity-check socket number. */
-	if ((s < 0) || (s >= (int)FD_SETSIZE)) {
+	if (s < 0) {
 		warn0("Invalid file descriptor for network event: %d", s);
 		goto err0;
 	}
@@ -135,16 +246,28 @@ events_network_register(int (*func)(void *), void * cookie, int s, int op)
 	if ((*r = events_mkrec(func, cookie)) == NULL)
 		goto err0;
 
-	/*
-	 * Increment events-registered counter; and if it was zero, start the
-	 * inter-select duration clock.
-	 */
-	if (nev++ == 0)
+	/* If we had no events registered, start a clock. */
+	if (nfds == 0)
 		events_network_selectstats_startclock();
+
+	/* If this descriptor isn't in the pollfd array, add it. */
+	if (socketlist_get(S, (size_t)s)->pollpos == (size_t)(-1)) {
+		if (growpollfd(s))
+			goto err1;
+	}
+
+	/* Set the appropriate event flag. */
+	if (op == EVENTS_NETWORK_OP_READ)
+		fds[socketlist_get(S, (size_t)s)->pollpos].events |= POLLIN;
+	else
+		fds[socketlist_get(S, (size_t)s)->pollpos].events |= POLLOUT;
 
 	/* Success! */
 	return (0);
 
+err1:
+	events_freerec(*r);
+	*r = NULL;
 err0:
 	/* Failure! */
 	return (-1);
@@ -162,11 +285,11 @@ events_network_cancel(int s, int op)
 	struct eventrec ** r;
 
 	/* Initialize if necessary. */
-	if (initsocketlist())
+	if (init())
 		goto err0;
 
 	/* Sanity-check socket number. */
-	if ((s < 0) || (s >= (int)FD_SETSIZE)) {
+	if (s < 0) {
 		warn0("Invalid file descriptor for network event: %d", s);
 		goto err0;
 	}
@@ -200,20 +323,14 @@ events_network_cancel(int s, int op)
 	events_freerec(*r);
 	*r = NULL;
 
-	/*
-	 * Since there is no longer an event registered for this socket /
-	 * operation pair, it doesn't make any sense for it to be ready.
-	 */
+	/* Clear the appropriate pollfd bit(s). */
 	if (op == EVENTS_NETWORK_OP_READ)
-		FD_CLR(s, &readfds);
+		clearbit(socketlist_get(S, (size_t)s)->pollpos, POLLIN);
 	else
-		FD_CLR(s, &writefds);
+		clearbit(socketlist_get(S, (size_t)s)->pollpos, POLLOUT);
 
-	/*
-	 * Decrement events-registered counter; and if it is becoming zero,
-	 * stop the inter-select duration clock.
-	 */
-	if (--nev == 0)
+	/* If that was the last remaining event, stop the clock. */
+	if (nfds == 0)
 		events_network_selectstats_stopclock();
 
 	/* Success! */
@@ -233,45 +350,41 @@ err0:
 int
 events_network_select(struct timeval * tv)
 {
-	size_t i;
+	int timeout;
 
 	/* Initialize if necessary. */
-	if (initsocketlist())
+	if (init())
 		goto err0;
 
-	/* Zero the fd sets... */
-	FD_ZERO(&readfds);
-	FD_ZERO(&writefds);
+	/*
+	 * Convert timeout to an integer number of ms.  We round up in order
+	 * to avoid creating busy loops when 0 < ${tv} < 1 ms.
+	 */
+	if (tv->tv_sec >= INT_MAX / 1000)
+		timeout = INT_MAX;
+	else
+		timeout = tv->tv_sec * 1000 + (tv->tv_usec + 999) / 1000;
 
-	/* ... and add the ones we care about. */
-	for (i = 0; i < socketlist_getsize(S); i++) {
-		if (socketlist_get(S, i)->reader)
-			FD_SET(i, &readfds);
-		if (socketlist_get(S, i)->writer)
-			FD_SET(i, &writefds);
-	}
-
-	/* We're about to call select! */
+	/* We're about to call poll! */
 	events_network_selectstats_select();
 
-	/* Select. */
-	while (select((int)socketlist_getsize(S), &readfds, &writefds,
-	    NULL, tv) == -1) {
+	/* Poll. */
+	while (poll(fds, nfds, timeout) == -1) {
 		/* EINTR is harmless. */
 		if (errno == EINTR)
 			continue;
 
 		/* Anything else is an error. */
-		warnp("select()");
+		warnp("poll()");
 		goto err0;
 	}
 
 	/* If we have any events registered, start the clock again. */
-	if (nev > 0)
+	if (nfds > 0)
 		events_network_selectstats_startclock();
 
-	/* We should start scanning for events at the beginning. */
-	fdscanpos = 0;
+	/* Start scanning at the last registered descriptor and work down. */
+	fdscanpos = nfds - 1;
 
 	/* Success! */
 	return (0);
@@ -292,33 +405,45 @@ struct eventrec *
 events_network_get(void)
 {
 	struct eventrec * r;
-	size_t nfds = socketlist_getsize(S);
 
 	/* We haven't found any events yet. */
 	r = NULL;
 
-	/* Scan through the fd sets looking for ready sockets. */
-	for (; fdscanpos < nfds; fdscanpos++) {
+	/* Scan through the pollfds looking for ready descriptors. */
+	for (; fdscanpos < nfds; fdscanpos--) {
+		/* Did we poll on an invalid descriptor? */
+		assert((fds[fdscanpos].revents & POLLNVAL) == 0);
+
+		/*
+		 * If either POLLERR ("an exceptional condition") or POLLHUP
+		 * ("has been disconnected") is set, then we should invoke
+		 * whatever callbacks we have available.
+		 */
+		if (fds[fdscanpos].revents & (POLLERR | POLLHUP)) {
+			fds[fdscanpos].revents &= ~(POLLERR | POLLHUP);
+			fds[fdscanpos].revents |= fds[fdscanpos].events;
+		}
+
 		/* Are we ready for reading? */
-		if (FD_ISSET(fdscanpos, &readfds)) {
-			r = socketlist_get(S, fdscanpos)->reader;
-			socketlist_get(S, fdscanpos)->reader = NULL;
-			if (--nev == 0)
-				events_network_selectstats_stopclock();
-			FD_CLR(fdscanpos, &readfds);
+		if (fds[fdscanpos].revents & POLLIN) {
+			r = socketlist_get(S, fds[fdscanpos].fd)->reader;
+			socketlist_get(S, fds[fdscanpos].fd)->reader = NULL;
+			clearbit(fdscanpos, POLLIN);
 			break;
 		}
 
-		/* Are we ready for writing? */
-		if (FD_ISSET(fdscanpos, &writefds)) {
-			r = socketlist_get(S, fdscanpos)->writer;
-			socketlist_get(S, fdscanpos)->writer = NULL;
-			if (--nev == 0)
-				events_network_selectstats_stopclock();
-			FD_CLR(fdscanpos, &writefds);
+		/* Are we ready for reading? */
+		if (fds[fdscanpos].revents & POLLOUT) {
+			r = socketlist_get(S, fds[fdscanpos].fd)->writer;
+			socketlist_get(S, fds[fdscanpos].fd)->writer = NULL;
+			clearbit(fdscanpos, POLLOUT);
 			break;
 		}
 	}
+
+	/* If we're returning the last registered event, stop the clock. */
+	if ((r != NULL) && (nfds == 0))
+		events_network_selectstats_stopclock();
 
 	/* Return the event we found, or NULL if we didn't find any. */
 	return (r);
@@ -338,8 +463,13 @@ events_network_shutdown(void)
 		return;
 
 	/* If we have any registered events, do nothing. */
-	if (nev > 0)
+	if (nfds > 0)
 		return;
+
+	/* Free the pollfd array. */
+	free(fds);
+	fds = NULL;
+	fds_alloc = 0;
 
 	/* Free the socket list. */
 	socketlist_free(S);


### PR DESCRIPTION
This has several effects: Most notably, it removes the FD_SETSIZE
limitation on descriptors, but it will also improve performance in
the unlikely case of waiting on a very sparse set of descriptors
(since poll is only passed the active list), and it may yield a
modest speedup in general (since the list is no longer regenerated
on each call to events_network_select, although the kernel still
needs to examine the entire list).

Note that this change is likely to result in events being returned
in a different order if multiple descriptors become ready at the
same time; this may expose previously-hidden bugs.

This change adds a dependency on ctassert.h; projects which do not
already include that file will need to add it.