### PR TITLE
Tidy up Travis-CI builds for the coverity branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,5 +17,7 @@ env:
     - COVERITY_SCAN_BUILD_COMMAND_PREPEND="cd tests/buildall"
     - COVERITY_SCAN_BUILD_COMMAND="make all clean"
 before_install:
+  - test $TRAVIS_BRANCH != coverity-scan -o ${TRAVIS_JOB_NUMBER##*.} = 1 || exit 0
   - curl -s "https://scan.coverity.com/scripts/travisci_build_coverity_scan.sh" | bash || true
+  - test $TRAVIS_BRANCH != coverity-scan || exit 0
 


### PR DESCRIPTION
1. Only run Coverity for the first of a set of builds.
2. Don't run the rest of the build and tests (hopefully they passed
when they ran on master before merging to the coverity branch!)