### PR TITLE
Avoid multiple-definition issues in CTASSERT

### DIFF
--- a/util/ctassert.h
+++ b/util/ctassert.h
@@ -14,6 +14,6 @@
 /* Define using libcperciva namespace to avoid collisions. */
 #define CTASSERT(x)			libcperciva_CTASSERT(x, __LINE__)
 #define libcperciva_CTASSERT(x, y)	libcperciva__CTASSERT(x, y)
-#define libcperciva__CTASSERT(x, y)	typedef char libcperciva__assert ## y[(x) ? 1 : -1]
+#define libcperciva__CTASSERT(x, y)	extern char libcperciva__assert ## y[(x) ? 1 : -1]
 
 #endif /* !_CTASSERT_H_ */


### PR DESCRIPTION
Redefining a typedef, even if the definition hasn't changed, is not
allowed in C99.  As a result, CTASSERT could cause problems if used
in header files, since the __LINE__ numbers could collide.  (Also,
but far less likely to occur by accident: If someone wrote
    CTASSERT(1); CTASSERT(2);
or equivalent code.)

Switch from defining a *typedef* for each compile-time assertion to
declaring an *external array*.  Since extern symbols can be declared
multiple times, this avoids the collision problem; but the same rules
about arrays not having negative size ensures that the assertion is
checked.