### PR TITLE
tests/valgrind: forbid inlining of pl_*()

### DIFF
--- a/tests/valgrind/potential-memleaks.c
+++ b/tests/valgrind/potential-memleaks.c
@@ -54,8 +54,8 @@ pl_nss_getpwnam(void)
 
 #define MEMLEAKTEST(x) { #x, x }
 static const struct memleaktest {
-	const char * name;
-	void (* func)(void);
+	const char * const name;
+	void (* const volatile func)(void);
 } tests[] = {
 	MEMLEAKTEST(pl_freebsd_link_lrt),
 	MEMLEAKTEST(pl_freebsd_printf),


### PR DESCRIPTION
We want the pl_*() names to be visible in the valgrind output, otherwise we
can't properly generalize the suppressions.

Unfortunately there doesn't seem to be a non-compiler-specific way to mark
functions as "not inline".  Fortunately, using a volatile function pointer
forces the compiler to not inline it.