### PR TITLE
Zero HMAC-SHA256 context in _Final.

### DIFF
--- a/alg/sha256.c
+++ b/alg/sha256.c
@@ -505,6 +505,9 @@ HMAC_SHA256_Final(uint8_t digest[32], HMAC_SHA256_CTX * ctx)
 	/* Call the real function. */
 	_HMAC_SHA256_Final(digest, ctx, tmp32, ihash);
 
+	/* Clear the context state. */
+	insecure_memzero(ctx, sizeof(HMAC_SHA256_CTX));
+
 	/* Clean the stack. */
 	insecure_memzero(tmp32, 288);
 	insecure_memzero(ihash, 32);


### PR DESCRIPTION
This zeroing was lost in commit d66012de (May 24, 2016) when most
of the functions in this file split into versions which performed
zeroing and internal function which did not.  Unfortunately, the
HMAC_SHA256_Final function had relied upon SHA256_Final to zero
its context, but was changed the use the internal (non-zeroing)
function and the necessary zeroing was not added.

Reported by:	Graham Percival