### PR TITLE
json: Bound the nesting depth of parsed values

### DIFF
--- a/util/json.c
+++ b/util/json.c
@@ -3,7 +3,14 @@
 
 #include "json.h"
 
-static const uint8_t * skip_value(const uint8_t *, const uint8_t *);
+/*
+ * Maximum depth of nested JSON values we will parse.  Values nested more
+ * deeply than this are treated as not-a-valid-value; this keeps the mutual
+ * recursion below from exhausting the stack on adversarial input.
+ */
+#define MAXDEPTH 1000
+
+static const uint8_t * skip_value(const uint8_t *, const uint8_t *, size_t);
 
 /* Advance past whitespace, if any. */
 static const uint8_t *
@@ -92,7 +99,7 @@ skip_number(const uint8_t * buf, const uint8_t * end)
 
 /* Advance past array. */
 static const uint8_t *
-skip_array(const uint8_t * buf, const uint8_t * end)
+skip_array(const uint8_t * buf, const uint8_t * end, size_t depth)
 {
 
 	/* Advance past the opening '[' and following whitespace. */
@@ -108,7 +115,7 @@ skip_array(const uint8_t * buf, const uint8_t * end)
 	/* Skip entries until we get to the end. */
 	do {
 		/* Skip a value. */
-		buf = skip_value(buf, end);
+		buf = skip_value(buf, end, depth);
 
 		/* Skip optional whitespace. */
 		buf = skip_ws(buf, end);
@@ -129,7 +136,7 @@ skip_array(const uint8_t * buf, const uint8_t * end)
 
 /* Advance past object. */
 static const uint8_t *
-skip_object(const uint8_t * buf, const uint8_t * end)
+skip_object(const uint8_t * buf, const uint8_t * end, size_t depth)
 {
 
 	/* Advance past the opening '{' and following whitespace. */
@@ -156,7 +163,7 @@ skip_object(const uint8_t * buf, const uint8_t * end)
 
 		/* Skip a whitespace, a value, and more whitespace. */
 		buf = skip_ws(buf, end);
-		buf = skip_value(buf, end);
+		buf = skip_value(buf, end, depth);
 		buf = skip_ws(buf, end);
 
 		/* Are we at the end? */
@@ -175,11 +182,15 @@ skip_object(const uint8_t * buf, const uint8_t * end)
 
 /* Advance past a JSON value. */
 static const uint8_t *
-skip_value(const uint8_t * buf, const uint8_t * end)
+skip_value(const uint8_t * buf, const uint8_t * end, size_t depth)
 {
 
 	/* If there's nothing here, return. */
 	if (buf == end)
+		return (end);
+
+	/* Refuse to recurse beyond MAXDEPTH nested values. */
+	if (depth >= MAXDEPTH)
 		return (end);
 
 	/* Handle different types of objects. */
@@ -194,10 +205,10 @@ skip_value(const uint8_t * buf, const uint8_t * end)
 		return (skip_string(buf, end));
 	case '[':
 		/* This must be an array.  Skip it. */
-		return (skip_array(buf, end));
+		return (skip_array(buf, end, depth + 1));
 	case '{':
 		/* This must be an object.  Skip it. */
-		return (skip_object(buf, end));
+		return (skip_object(buf, end, depth + 1));
 	default:
 		/* Could this plausibly be a number? */
 		if (strchr(numchars, buf[0]) != NULL)
@@ -331,7 +342,7 @@ json_find(const uint8_t * buf, const uint8_t * end, const char * s)
 			return (buf);
 
 		/* Skip this JSON object. */
-		buf = skip_value(buf, end);
+		buf = skip_value(buf, end, 0);
 
 		/*
 		 * After optional whitespace we should have a ','.  (Or we


### PR DESCRIPTION
Fixes #566.

**LLM disclosure, per `AGENTS.md`:** I am an LLM (Claude), working on behalf of
the account owner. I am available to discuss this change and revise it in
response to review feedback.

## What this fixes

`skip_value()` recursed into `skip_array()` / `skip_object()` with no bound on
nesting depth, so a sufficiently nested value exhausted the stack and killed
the process with `SIGSEGV`. Measurements and a reproducer are in #566; the
short version is that 175,000 nested `[` characters (a 175 KB input) is enough
on an 8 MB stack, and `kivaloo`'s `dynamodb-kv` hands `json_find()` response
bodies of up to 1 MB.

## Approach

A depth counter is threaded through the mutual recursion. `skip_value()`
returns `end` once the depth reaches `MAXDEPTH`, which is the value
`json_find()` already returns for input it cannot parse, so no new error path
is needed.

`MAXDEPTH` is set to 1000, which bounds the recursion at roughly 48 KB of
stack. The JSON these callers actually parse (DynamoDB `GetItem` responses,
`DescribeTable`, error bodies) is a handful of levels deep. I am happy to
change the limit or make it a build-time knob if you would prefer a different
number.

## Testing

- `tests/json` passes (`SUCCESS`).
- The #566 reproducer returns normally at 175,000, 1,000,000 and 5,000,000
  nesting levels instead of crashing.
- `cc -O2 -Wall -Wextra -Werror -c util/json.c` is clean.
- Spot-checked that ordinary nested lookups still resolve
  (`{"food":[123,234,{"x":[1,2,[3,[4]]]}],"foo":"bar"}` -> `"bar"}`).

## Notes

- This is based on master, so it does not include PR #556; the two touch
  `skip_object()` in different places and the crash in #566 reproduces with
  #556 applied, so they are independent.
- Per `AGENTS.md`, bounties are for reports rather than patches -- I filed the
  report as #566 and am sending this only because it is small. No test was
  added to `tests/json/main.c` because the existing harness uses string
  literals and a depth-limit case needs a generated input; say the word and I
  will wire one up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
